### PR TITLE
Add new 'format' function to build MQTT topic from a topic pattern and a set of values

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,28 @@ function parse(topic) {
 	var result = {
 		regex: make_regex(tokens),
 		getParams: make_pram_getter(tokens),
-		topic: make_clean_topic(tokens)
+		topic: make_clean_topic(tokens),
+		format: make_formatter(topic)
 	};
 	result.exec = exec.bind(result);
 	return result;
 };
+
+function make_formatter(topic) {
+	function formatter(params) {
+		var tokens = tokenize(topic)
+		return tokens.map(function(token) {
+			if (token[0] == '+' || token[0] == '#') {
+				return params[token.slice(1)]
+			} else {
+				return token
+			}
+		}).flat().join('/')
+	}
+	return formatter
+
+}
+
 
 /**
  * Matches regex against topic, returns params if successful


### PR DESCRIPTION
This PR adds a new method to the mqtt_regex result that allows the user to build a valid MQTT topic using a topic pattern and a set of values. 

Usage is as follows:
```
var topic = mqtt_regex("/feeder/+feederId/needInit")
var params = {"feederId":"feeder-1"}
topic.format(params)
```

This should return a formatted MQTT topic that looks like `/feeder/feeder-1/needInit`